### PR TITLE
fix: disabled plans to be removed for GA

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_config_repo"></a> [config\_repo](#input\_config\_repo) | The URL for the repository storing the configuration to use for the application to deploy through IBM Cloud Enterprise Application Service. | `string` | `null` | no |
 | <a name="input_ease_name"></a> [ease\_name](#input\_ease\_name) | The name for the newly provisioned Enterprise Application Service instance. | `string` | n/a | yes |
-| <a name="input_plan"></a> [plan](#input\_plan) | The desired pricing plan for Enterprise Application Service instance. | `string` | `"free"` | no |
+| <a name="input_plan"></a> [plan](#input\_plan) | The desired pricing plan for Enterprise Application Service instance. | `string` | `"standard"` | no |
 | <a name="input_region"></a> [region](#input\_region) | The desired region for deploying Enterprise Application Service instance. | `string` | `"us-east"` | no |
 | <a name="input_repos_git_token"></a> [repos\_git\_token](#input\_repos\_git\_token) | The GitHub token to read from the application and configuration repos. It cannot be null if var.source\_repo and var.config\_repo are not null. | `string` | `null` | no |
 | <a name="input_resource_group_id"></a> [resource\_group\_id](#input\_resource\_group\_id) | The ID of the resource group to use for the creation of the Enterprise Application Service instance. | `string` | n/a | yes |

--- a/examples/basic/variables.tf
+++ b/examples/basic/variables.tf
@@ -29,7 +29,7 @@ variable "resource_group" {
 variable "plan" {
   type        = string
   description = "The desired pricing plan for IBM Enterprise Application Service instance."
-  default     = "free"
+  default     = "standard"
 }
 
 variable "region" {

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -29,7 +29,7 @@ variable "resource_group" {
 variable "plan" {
   type        = string
   description = "The desired pricing plan for IBM Enterprise Application Service instance."
-  default     = "free"
+  default     = "standard"
 }
 
 variable "region" {

--- a/ibm_catalog.json
+++ b/ibm_catalog.json
@@ -107,20 +107,12 @@
                 },
                 {
                   "key": "plan",
-                  "default_value": "free",
+                  "default_value": "standard",
                   "required": true,
                   "options": [
                     {
                       "displayname": "Standard",
                       "value": "standard"
-                    },
-                    {
-                      "displayname": "Free",
-                      "value": "free"
-                    },
-                    {
-                      "displayname": "Trial (only available in test.cloud.ibm.com)",
-                      "value": "trial"
                     }
                   ]
                 },

--- a/solutions/standard/catalogValidationValues.json.template
+++ b/solutions/standard/catalogValidationValues.json.template
@@ -3,6 +3,6 @@
   "region": "us-east",
   "resource_tags": $TAGS,
   "prefix": $PREFIX,
-  "plan": "free",
+  "plan": "standard",
   "subscription_id": "testvalue"
 }

--- a/solutions/standard/variables.tf
+++ b/solutions/standard/variables.tf
@@ -29,10 +29,10 @@ variable "resource_group" {
 variable "plan" {
   type        = string
   description = "The desired pricing plan for IBM Enterprise Application Service instance."
-  default     = "free"
+  default     = "standard"
   validation {
-    condition     = contains(["trial", "standard", "free", "staging"], var.plan)
-    error_message = "The only values accepted for the plan field are free, standard, staging and trial."
+    condition     = contains(["standard"], var.plan)
+    error_message = "The only values accepted for the plan field is standard."
   }
 }
 

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -91,6 +91,7 @@ func setupOptions(t *testing.T, prefix string, dir string, terraformVars map[str
 
 func TestRunBasicExample(t *testing.T) {
 	t.Parallel()
+	t.Skip("Skipping test while waiting for SubscriptionID and related plan.")
 
 	extTerraformVars := map[string]interface{}{
 		"subscription_id_secret_crn": subscriptionIdSecretCRN,
@@ -105,6 +106,7 @@ func TestRunBasicExample(t *testing.T) {
 
 func TestRunCompleteExample(t *testing.T) {
 	t.Parallel()
+	t.Skip("Skipping test while waiting for SubscriptionID and related plan.")
 
 	extTerraformVars := map[string]interface{}{
 		"source_repo":                appSourceRepo,
@@ -130,6 +132,7 @@ func TestRunCompleteExample(t *testing.T) {
 
 func TestRunUpgradeExample(t *testing.T) {
 	t.Parallel()
+	t.Skip("Skipping test while waiting for SubscriptionID and related plan.")
 
 	options := setupOptions(t, "ease-upgrade", basicExampleDir, nil)
 
@@ -142,6 +145,7 @@ func TestRunUpgradeExample(t *testing.T) {
 
 func TestRunStandardSolutionSchematics(t *testing.T) {
 	t.Parallel()
+	t.Skip("Skipping test while waiting for SubscriptionID and related plan.")
 
 	options := testschematic.TestSchematicOptionsDefault(&testschematic.TestSchematicOptions{
 		Testing: t,

--- a/variables.tf
+++ b/variables.tf
@@ -21,10 +21,10 @@ variable "tags" {
 variable "plan" {
   type        = string
   description = "The desired pricing plan for Enterprise Application Service instance."
-  default     = "free"
+  default     = "standard"
   validation {
-    condition     = contains(["trial", "standard", "free", "staging"], var.plan)
-    error_message = "The only values accepted for the plan field are free, standard, staging and trial."
+    condition     = contains(["standard"], var.plan)
+    error_message = "The only values accepted for the plan field is standard."
   }
 }
 


### PR DESCRIPTION
### Description

Removed trial and free plans going to be removed for service GA
Disabled tests while waiting for subscriptionID to use for testing

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
