### PR TITLE
Set terraform min version to 1.9 and update on catalog json input vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Update status and "latest release" badges:
   1. For the status options, see https://terraform-ibm-modules.github.io/documentation/#/badge-status
   2. Update the "latest release" badge to point to the correct module's repo. Replace "terraform-ibm-module-template" in two places.
 -->
-[![Incubating (Not yet consumable)](https://img.shields.io/badge/status-Incubating%20(Not%20yet%20consumable)-red)](https://terraform-ibm-modules.github.io/documentation/#/badge-status)
+[![Stable (With quality checks)](https://img.shields.io/badge/Status-Stable%20(With%20quality%20checks)-green)](https://terraform-ibm-modules.github.io/documentation/#/badge-status)
 [![latest release](https://img.shields.io/github/v/release/terraform-ibm-modules/terraform-ibm-enterprise-app-java?logo=GitHub&sort=semver)](https://github.com/terraform-ibm-modules/terraform-ibm-enterprise-app-java/releases/latest)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)
 [![Renovate enabled](https://img.shields.io/badge/renovate-enabled-brightgreen.svg)](https://renovatebot.com/)

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ No permissions are needed to run this module.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9.0 |
 | <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >= 1.67.0, < 2.0.0 |
 
 ### Modules

--- a/examples/basic/version.tf
+++ b/examples/basic/version.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.3.0"
+  required_version = ">= 1.9.0"
   required_providers {
     ibm = {
       source  = "IBM-Cloud/ibm"

--- a/examples/bdr_complete/version.tf
+++ b/examples/bdr_complete/version.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.3.0"
+  required_version = ">= 1.9.0"
   required_providers {
     ibm = {
       source  = "IBM-Cloud/ibm"

--- a/examples/dr_complete/version.tf
+++ b/examples/dr_complete/version.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.3.0"
+  required_version = ">= 1.9.0"
   required_providers {
     ibm = {
       source  = "IBM-Cloud/ibm"

--- a/ibm_catalog.json
+++ b/ibm_catalog.json
@@ -84,21 +84,27 @@
             "configuration": [
               {
                 "key": "ibmcloud_api_key",
+                "type": "password",
                 "required": true
               },
               {
-                "key": "use_existing_resource_group"
+                "key": "use_existing_resource_group",
+                "type": "boolean",
+                "required": true
               },
               {
-                "key": "resource_group_name"
+                "key": "resource_group_name",
+                "type": "string",
+                "required": true
               },
               {
-                "key": "ease_name"
+                "key": "ease_name",
+                "type": "string"
               },
               {
                 "key": "region",
+                "type": "string",
                 "required": true,
-                "default_value": "us-east",
                 "options": [
                   {
                     "displayname": "Washington (us-east)",
@@ -108,12 +114,13 @@
               },
               {
                 "key": "prefix",
-                "required": true,
-                "description": "Prefix to add to all resources created by this solution. To not use any prefix value, you can enter the string `__NULL__`."
+                "type": "string"
               },
               {
                 "key": "plan",
                 "required": true,
+                "type": "string",
+                "default_value": "standard",
                 "options": [
                   {
                     "displayname": "Standard",
@@ -122,36 +129,44 @@
                 ]
               },
               {
-                "key": "resource_tags"
+                "key": "resource_tags",
+                "type": "array"
               },
               {
-                "key": "source_repo"
+                "key": "source_repo",
+                "type": "string"
               },
               {
-                "key": "config_repo"
+                "key": "config_repo",
+                "type": "string"
               },
               {
-                "key": "repos_git_token_secret_crn"
+                "key": "repos_git_token_secret_crn",
+                "type": "string"
               },
               {
-                "key": "subscription_id_secret_crn"
+                "key": "subscription_id_secret_crn",
+                "type": "string"
               },
               {
-                "key": "repos_git_token"
+                "key": "repos_git_token",
+                "type": "password"
               },
               {
-                "key": "mq_s2s_policy_enable"
+                "key": "mq_s2s_policy_enable",
+                "type": "boolean"
               },
               {
-                "key": "mq_s2s_policy_roles"
+                "key": "mq_s2s_policy_roles",
+                "type": "array"
               },
               {
-                "key": "mq_s2s_policy_target_resource_id"
+                "key": "mq_s2s_policy_target_resource_id",
+                "type": "string"
               },
               {
                 "key": "source_repo_type",
-                "required": true,
-                "default_value": "git",
+                "type": "string",
                 "options": [
                   {
                     "displayname": "GitHub",
@@ -164,10 +179,12 @@
                 ]
               },
               {
-                "key": "maven_repository_username"
+                "key": "maven_repository_username",
+                "type": "string"
               },
               {
-                "key": "maven_repository_password"
+                "key": "maven_repository_password",
+                "type": "password"
               }
             ]
           }

--- a/ibm_catalog.json
+++ b/ibm_catalog.json
@@ -153,6 +153,10 @@
                 "type": "password"
               },
               {
+                "key": "subscription_id",
+                "type": "password"
+              },
+              {
                 "key": "mq_s2s_policy_enable",
                 "type": "boolean"
               },

--- a/ibm_catalog.json
+++ b/ibm_catalog.json
@@ -83,8 +83,7 @@
             },
             "configuration": [
               {
-                "key": "ibmcloud_api_key",
-                "required": true
+                "key": "ibmcloud_api_key"
               },
               {
                 "key": "use_existing_resource_group",

--- a/ibm_catalog.json
+++ b/ibm_catalog.json
@@ -84,26 +84,21 @@
             "configuration": [
               {
                 "key": "ibmcloud_api_key",
-                "type": "password",
                 "required": true
               },
               {
                 "key": "use_existing_resource_group",
-                "type": "boolean",
                 "required": true
               },
               {
                 "key": "resource_group_name",
-                "type": "string",
                 "required": true
               },
               {
-                "key": "ease_name",
-                "type": "string"
+                "key": "ease_name"
               },
               {
                 "key": "region",
-                "type": "string",
                 "required": true,
                 "options": [
                   {
@@ -113,13 +108,11 @@
                 ]
               },
               {
-                "key": "prefix",
-                "type": "string"
+                "key": "prefix"
               },
               {
                 "key": "plan",
                 "required": true,
-                "type": "string",
                 "default_value": "standard",
                 "options": [
                   {
@@ -129,48 +122,37 @@
                 ]
               },
               {
-                "key": "resource_tags",
-                "type": "array"
+                "key": "resource_tags"
               },
               {
-                "key": "source_repo",
-                "type": "string"
+                "key": "source_repo"
               },
               {
-                "key": "config_repo",
-                "type": "string"
+                "key": "config_repo"
               },
               {
-                "key": "repos_git_token_secret_crn",
-                "type": "string"
+                "key": "repos_git_token_secret_crn"
               },
               {
-                "key": "subscription_id_secret_crn",
-                "type": "string"
+                "key": "subscription_id_secret_crn"
               },
               {
-                "key": "repos_git_token",
-                "type": "password"
+                "key": "repos_git_token"
               },
               {
-                "key": "subscription_id",
-                "type": "password"
+                "key": "subscription_id"
               },
               {
-                "key": "mq_s2s_policy_enable",
-                "type": "boolean"
+                "key": "mq_s2s_policy_enable"
               },
               {
-                "key": "mq_s2s_policy_roles",
-                "type": "array"
+                "key": "mq_s2s_policy_roles"
               },
               {
-                "key": "mq_s2s_policy_target_resource_id",
-                "type": "string"
+                "key": "mq_s2s_policy_target_resource_id"
               },
               {
                 "key": "source_repo_type",
-                "type": "string",
                 "options": [
                   {
                     "displayname": "GitHub",
@@ -183,12 +165,10 @@
                 ]
               },
               {
-                "key": "maven_repository_username",
-                "type": "string"
+                "key": "maven_repository_username"
               },
               {
-                "key": "maven_repository_password",
-                "type": "password"
+                "key": "maven_repository_password"
               }
             ]
           }

--- a/ibm_catalog.json
+++ b/ibm_catalog.json
@@ -90,8 +90,7 @@
                 "required": true
               },
               {
-                "key": "resource_group_name",
-                "required": true
+                "key": "resource_group_name"
               },
               {
                 "key": "ease_name"

--- a/ibm_catalog.json
+++ b/ibm_catalog.json
@@ -107,7 +107,8 @@
               },
               {
                 "key": "prefix",
-                "required": true
+                "required": true,
+                "description": "Prefix to add to all resources created by this solution. To not use any prefix value, you can enter the string `__NULL__`."
               },
               {
                 "key": "plan",

--- a/ibm_catalog.json
+++ b/ibm_catalog.json
@@ -108,12 +108,12 @@
                 ]
               },
               {
-                "key": "prefix"
+                "key": "prefix",
+                "required": true
               },
               {
                 "key": "plan",
                 "required": true,
-                "default_value": "standard",
                 "options": [
                   {
                     "displayname": "Standard",

--- a/solutions/standard/version.tf
+++ b/solutions/standard/version.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.3.0"
+  required_version = ">= 1.9.0"
   required_providers {
     ibm = {
       source  = "IBM-Cloud/ibm"

--- a/version.tf
+++ b/version.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.3.0"
+  required_version = ">= 1.9.0"
   required_providers {
     ibm = {
       source  = "ibm-cloud/ibm"


### PR DESCRIPTION
### Description

Updated terraform min version to module, DA and examples for cross objects validation
Updated catalog json input vars setting by adding catalog variable types
Moved badge to stable

Region set to custom list instead of using the catalog region combobox as the service supports only us-east in this moment

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [X] Major release (`X.x.x`)

##### Release notes content

Updated terraform min version to module, DA and examples for cross objects validation
Updated catalog json input vars setting by adding catalog variable types
Moved badge to stable status

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
