### PR TITLE
Enabled Service to Service policies by default in DA

### DIFF
--- a/ibm_catalog.json
+++ b/ibm_catalog.json
@@ -66,8 +66,8 @@
                   "description": "Supports application build and configuration using dedicated repositories"
                 },
                 {
-                  "title": "Supports Service To Service authorisation policy creation to a MQ instance",
-                  "description": "Supports Service To Service authorisation policy creation to a MQ instance to allow the Enterprise Application Service for Java to connect to this"
+                  "title": "Supports Service To Service authorisation policy creation to a MQ and DB2 instances",
+                  "description": "Supports Service To Service authorisation policy creation to a MQ and DB2 instances to allow the Enterprise Application Service for Java to connect to them"
                 }
               ],
               "diagrams": [

--- a/ibm_catalog.json
+++ b/ibm_catalog.json
@@ -110,6 +110,10 @@
                   {
                     "displayname": "Standard",
                     "value": "standard"
+                  },
+                  {
+                    "displayname": "Trial (for allowlisted accounts only)",
+                    "value": "free"
                   }
                 ]
               },

--- a/solutions/fully-configurable/README.md
+++ b/solutions/fully-configurable/README.md
@@ -4,8 +4,8 @@ This architecture creates an instance of Enterprise Application Service for Java
 
 - A resource group, if an existing one is not passed in.
 - An Enterprise Application Service for Java instance.
-- An optional [Service to Service authorisation policy](https://cloud.ibm.com/docs/account?topic=account-serviceauth) to authorise the Enterprise Application instance to reach an instance of MQ service. The authorisation policy is configured at MQ resource instance scope if enabled.
-- An optional [Service to Service authorisation policy](https://cloud.ibm.com/docs/account?topic=account-serviceauth) to authorise the Enterprise Application instance to reach an instance of DB2 service. The authorisation policy is configured at DB2 resource instance scope if enabled.
+- An optional [Service to Service authorisation policy](https://cloud.ibm.com/docs/account?topic=account-serviceauth) to authorise the Enterprise Application instance to reach an instance of MQ service. If enabled, the authorisation policy is configured at MQ resource instance scope if its CRN is provided, otherwise the policy is created for MQ service at account scope, with the account owner of the Enterprise Application instance as target account.
+- An optional [Service to Service authorisation policy](https://cloud.ibm.com/docs/account?topic=account-serviceauth) to authorise the Enterprise Application instance to reach an instance of DB2 service. If enabled, the authorisation policy is configured at DB2 resource instance scope if its CRN is provided, otherwise the policy is created for DB2 service at account scope, with the account owner of the Enterprise Application instance as target account.
 
 <!-- ![Enterprise Application Service for Java architecture](../../reference-architecture/deployable-architecture-ease.svg) -->
 

--- a/solutions/fully-configurable/main.tf
+++ b/solutions/fully-configurable/main.tf
@@ -125,9 +125,9 @@ module "crn_parser_mq_capacity_instance_crn" {
 data "ibm_iam_account_settings" "provider_account" {}
 
 locals {
-  # for S2S policy, the source accountID is the one owning the ease instance and the target is the account creating the policy, so in this case are the same account
+  # for S2S policy, the source accountID is the one owning the Enterprise Application Service instance and the target is the account retrieved from the MQ instance CRN or, if this is null, the one creating the policy and owning the Enterprise Application Service instance
   mq_s2s_subject_account_id = data.ibm_iam_account_settings.provider_account.account_id
-  mq_s2s_target_account_id  = var.mq_s2s_policy_target_crn != null ? module.crn_parser_mq_capacity_instance_crn[0].account_id : null
+  mq_s2s_target_account_id  = var.mq_s2s_policy_target_crn != null ? module.crn_parser_mq_capacity_instance_crn[0].account_id : data.ibm_iam_account_settings.provider_account.account_id
 }
 
 # creating S2S policy if enabled
@@ -188,9 +188,9 @@ module "crn_parser_db2_instance_crn" {
 }
 
 locals {
-  # for S2S policy, the source accountID is the one owning the ease instance and the target is the account creating the policy, so in this case are the same account
+  # for S2S policy, the source accountID is the one owning the Enterprise Application Service instance and the target is the account retrieved from the DB2 instance CRN or, if this is null, the one creating the policy and owning the Enterprise Application Service instance
   db2_s2s_subject_account_id = data.ibm_iam_account_settings.provider_account.account_id
-  db2_s2s_target_account_id  = var.db2_s2s_policy_target_crn != null ? module.crn_parser_db2_instance_crn[0].account_id : null
+  db2_s2s_target_account_id  = var.db2_s2s_policy_target_crn != null ? module.crn_parser_db2_instance_crn[0].account_id : data.ibm_iam_account_settings.provider_account.account_id
 }
 
 # creating S2S policy if enabled

--- a/solutions/fully-configurable/main.tf
+++ b/solutions/fully-configurable/main.tf
@@ -130,9 +130,9 @@ locals {
   mq_s2s_target_account_id  = var.mq_s2s_policy_target_crn != null ? module.crn_parser_mq_capacity_instance_crn[0].account_id : data.ibm_iam_account_settings.provider_account.account_id
 }
 
-# creating S2S policy if enabled
-resource "ibm_iam_authorization_policy" "mq_s2s_policy" {
-  count = var.mq_s2s_policy_enable == true ? 1 : 0
+# creating S2S policy to MQ if enabled - MQ instance scope
+resource "ibm_iam_authorization_policy" "mq_s2s_policy_crn_scope" {
+  count = var.mq_s2s_policy_enable == true && var.mq_s2s_policy_target_crn != null ? 1 : 0
   roles = var.mq_s2s_policy_roles
 
   # limiting the source accountID of S2S policy to the provider account ID is used
@@ -168,11 +168,50 @@ resource "ibm_iam_authorization_policy" "mq_s2s_policy" {
     value    = "mqcloud"
   }
 
-  # limiting the target serviceInstance of S2S policy to the MQ instance ID
   resource_attributes {
     name     = "serviceInstance"
     operator = "stringEquals"
-    value    = var.mq_s2s_policy_target_crn != null ? module.crn_parser_mq_capacity_instance_crn[0].service_instance : null
+    value    = module.crn_parser_mq_capacity_instance_crn[0].service_instance
+  }
+
+}
+
+# creating S2S policy to MQ if enabled - account scope scope
+resource "ibm_iam_authorization_policy" "mq_s2s_policy_account_scope" {
+  count = var.mq_s2s_policy_enable == true && var.mq_s2s_policy_target_crn == null ? 1 : 0
+  roles = var.mq_s2s_policy_roles
+
+  # limiting the source accountID of S2S policy to the provider account ID is used
+  subject_attributes {
+    name     = "accountId"
+    operator = "stringEquals"
+    value    = local.mq_s2s_subject_account_id
+  }
+
+  subject_attributes {
+    name     = "serviceName"
+    operator = "stringEquals"
+    value    = "enterprise-app-java"
+  }
+
+  # limiting the target serviceInstance of S2S policy to the Enterprise Application Service instance ID
+  subject_attributes {
+    name     = "serviceInstance"
+    operator = "stringEquals"
+    value    = module.ease.ease_instance.guid
+  }
+
+  # limiting the target accountID of S2S policy to the provider account ID
+  resource_attributes {
+    name     = "accountId"
+    operator = "stringEquals"
+    value    = local.mq_s2s_target_account_id
+  }
+
+  resource_attributes {
+    name     = "serviceName"
+    operator = "stringEquals"
+    value    = "mqcloud"
   }
 
 }
@@ -193,9 +232,9 @@ locals {
   db2_s2s_target_account_id  = var.db2_s2s_policy_target_crn != null ? module.crn_parser_db2_instance_crn[0].account_id : data.ibm_iam_account_settings.provider_account.account_id
 }
 
-# creating S2S policy if enabled
-resource "ibm_iam_authorization_policy" "db2_s2s_policy" {
-  count = var.db2_s2s_policy_enable == true ? 1 : 0
+# creating S2S policy to DB2 if enabled - DB2 instance scope
+resource "ibm_iam_authorization_policy" "db2_s2s_policy_crn_scope" {
+  count = var.db2_s2s_policy_enable == true && var.db2_s2s_policy_target_crn != null ? 1 : 0
   roles = var.db2_s2s_policy_roles
 
   # limiting the source accountID of S2S policy to the provider account ID
@@ -231,10 +270,49 @@ resource "ibm_iam_authorization_policy" "db2_s2s_policy" {
     value    = "dashdb-for-transactions"
   }
 
-  # limiting the target serviceInstance of S2S policy to the DB2 instance ID
   resource_attributes {
     name     = "serviceInstance"
     operator = "stringEquals"
-    value    = var.db2_s2s_policy_target_crn != null ? module.crn_parser_db2_instance_crn[0].service_instance : null
+    value    = module.crn_parser_db2_instance_crn[0].service_instance
   }
+}
+
+# creating S2S policy to DB2 if enabled - account scope
+resource "ibm_iam_authorization_policy" "db2_s2s_policy_account_scope" {
+  count = var.db2_s2s_policy_enable == true && var.db2_s2s_policy_target_crn == null ? 1 : 0
+  roles = var.db2_s2s_policy_roles
+
+  # limiting the source accountID of S2S policy to the provider account ID
+  subject_attributes {
+    name     = "accountId"
+    operator = "stringEquals"
+    value    = local.db2_s2s_subject_account_id
+  }
+
+  subject_attributes {
+    name     = "serviceName"
+    operator = "stringEquals"
+    value    = "enterprise-app-java"
+  }
+
+  # limiting the target serviceInstance of S2S policy to the Enterprise Application Service instance ID
+  subject_attributes {
+    name     = "serviceInstance"
+    operator = "stringEquals"
+    value    = module.ease.ease_instance.guid
+  }
+
+  # limiting the target accountID of S2S policy to the provider account ID
+  resource_attributes {
+    name     = "accountId"
+    operator = "stringEquals"
+    value    = local.db2_s2s_target_account_id
+  }
+
+  resource_attributes {
+    name     = "serviceName"
+    operator = "stringEquals"
+    value    = "dashdb-for-transactions"
+  }
+
 }

--- a/solutions/fully-configurable/outputs.tf
+++ b/solutions/fully-configurable/outputs.tf
@@ -49,30 +49,40 @@ output "ease_instance_resource_status" {
 
 output "mq_capacity_instance_crn" {
   description = "MQ capacity instance crn"
-  value       = var.mq_s2s_policy_target_crn
+  value       = var.mq_s2s_policy_target_crn != null ? var.mq_s2s_policy_target_crn : null
 }
 
-output "mq_s2s_policy_id" {
-  description = "Service to Service policy id for MQ capacity instance"
-  value       = var.mq_s2s_policy_enable == true ? ibm_iam_authorization_policy.mq_s2s_policy[0].id : null
+output "mq_s2s_policy_id_crn_scope" {
+  description = "Service to Service policy id to MQ capacity instance"
+  value       = var.mq_s2s_policy_enable == true && var.mq_s2s_policy_target_crn != null ? ibm_iam_authorization_policy.mq_s2s_policy_crn_scope[0].id : null
+}
+
+output "mq_s2s_policy_id_account_scope" {
+  description = "Service to Service policy id to MQ service with account scope"
+  value       = var.mq_s2s_policy_enable == true && var.mq_s2s_policy_target_crn == null ? ibm_iam_authorization_policy.mq_s2s_policy_account_scope[0].id : null
 }
 
 output "mq_s2s_resource_id" {
   description = "Target Resource ID for the Service to Service policy for MQ capacity instance"
-  value       = var.mq_s2s_policy_enable == true ? module.crn_parser_mq_capacity_instance_crn[0].service_instance : null
+  value       = var.mq_s2s_policy_target_crn != null ? module.crn_parser_mq_capacity_instance_crn[0].service_instance : null
 }
 
 output "db2_instance_crn" {
   description = "DB2 instance crn"
-  value       = var.db2_s2s_policy_target_crn
+  value       = var.db2_s2s_policy_target_crn != null ? var.db2_s2s_policy_target_crn : null
 }
 
-output "db2_s2s_policy_id" {
+output "db2_s2s_policy_id_crn_scope" {
   description = "Service to Service policy id for DB2 instance"
-  value       = var.db2_s2s_policy_enable == true ? ibm_iam_authorization_policy.db2_s2s_policy[0].id : null
+  value       = var.db2_s2s_policy_enable == true && var.db2_s2s_policy_target_crn != null ? ibm_iam_authorization_policy.db2_s2s_policy_crn_scope[0].id : null
+}
+
+output "db2_s2s_policy_id_account_scope" {
+  description = "Service to Service policy id to DB2 service with account scope"
+  value       = var.db2_s2s_policy_enable == true && var.db2_s2s_policy_target_crn != null ? ibm_iam_authorization_policy.db2_s2s_policy_account_scope[0].id : null
 }
 
 output "db2_s2s_resource_id" {
   description = "Target Resource ID for the Service to Service policy for DB2 instance"
-  value       = var.db2_s2s_policy_enable == true ? module.crn_parser_db2_instance_crn[0].service_instance : null
+  value       = var.db2_s2s_policy_target_crn != null ? module.crn_parser_db2_instance_crn[0].service_instance : null
 }

--- a/solutions/fully-configurable/variables.tf
+++ b/solutions/fully-configurable/variables.tf
@@ -104,8 +104,8 @@ variable "subscription_id_secret_crn" {
 
 variable "mq_s2s_policy_enable" {
   type        = bool
-  description = "Flag to enable creation of the Service to Service policy to enable the Enterprise Application Service instance to reach MQ instance. Default to false."
-  default     = false
+  description = "Flag to enable creation of the Service to Service policy to enable the Enterprise Application Service instance to reach MQ instance. Default to true."
+  default     = true
 }
 
 variable "mq_s2s_policy_roles" {
@@ -122,12 +122,8 @@ variable "mq_s2s_policy_roles" {
 
 variable "mq_s2s_policy_target_crn" {
   type        = string
-  description = "MQ resource capacity instance CRN to set as target for the Service to Service policy. If mq_s2s_policy_enable is true this input variable is mandatory. Default to null."
+  description = "MQ resource capacity instance CRN to restrict the target for the Service to Service policy to MQ service instance. If mq_s2s_policy_enable is true but this is null the S2S policy is created at account scope on Enterprise Application Service instance account owner. Default to null."
   default     = null
-  validation {
-    condition     = var.mq_s2s_policy_enable == true ? var.mq_s2s_policy_target_crn != null : true
-    error_message = "If var.mq_s2s_policy_enable is true the MQ instance CRN to set as target of Service to Service policy cannot be null."
-  }
 }
 
 ###################################################
@@ -136,8 +132,8 @@ variable "mq_s2s_policy_target_crn" {
 
 variable "db2_s2s_policy_enable" {
   type        = bool
-  description = "Flag to enable creation of the Service to Service policy to enable the Enterprise Application Service instance to reach DB2 instance. Default to false."
-  default     = false
+  description = "Flag to enable creation of the Service to Service policy to enable the Enterprise Application Service instance to reach DB2 instance. Default to true."
+  default     = true
 }
 
 variable "db2_s2s_policy_roles" {
@@ -154,12 +150,8 @@ variable "db2_s2s_policy_roles" {
 
 variable "db2_s2s_policy_target_crn" {
   type        = string
-  description = "DB2 resource instance CRN to set as target for the Service to Service policy. If db2_s2s_policy_enable is true this input variable is mandatory. Default to null."
+  description = "DB2 resource capacity instance CRN to restrict the target for the Service to Service policy to DB2 service instance. If db2_s2s_policy_enable is true but this is null the S2S policy is created at account scope on Enterprise Application Service instance account owner. Default to null."
   default     = null
-  validation {
-    condition     = var.db2_s2s_policy_enable == true ? var.db2_s2s_policy_target_crn != null : true
-    error_message = "If var.db2_s2s_policy_enable is true the SB2 instance CRN to set as target of Service to Service policy cannot be null."
-  }
 }
 
 ###################################################


### PR DESCRIPTION
### Description

Enabled Service to Service policies by default in DA
If MQ/DB2 crns are not provided the policies, if enabled, are configured at account scope using the account owner of ease instance
Trial plan is enabled for allowlisted account in DA configuration

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [x] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

Enabled Service to Service policies by default in DA
If MQ/DB2 crns are not provided the policies, if enabled, are configured at account scope using the account owner of ease instance
Trial plan is enabled for allowlisted account in DA configuration

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [x] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
